### PR TITLE
Fix bugs in encoder.js

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -166,12 +166,12 @@ Encoder.prototype._writeHeader = function (output, fn) {
   op_comments.replace();
   op_code.replace();
 
-  output(op_header); // automatically gets placed in its own `ogg_page`
-  output(op_comments);
+  this.push(op_header); // automatically gets placed in its own `ogg_page`
+  this.push(op_comments);
 
   // specify that a page flush() call is required after this 3rd packet
   op_code.flush = true;
-  output(op_code);
+  this.push(op_code);
 
   // don't call this function again
   this._headerWritten = true;
@@ -242,7 +242,8 @@ Encoder.prototype._blockout = function (output, fn) {
       self._flushpacket(output, afterFlush);
     } else if (0 === rtn) {
       // need more PCM data...
-      fn();
+      if (fn !== undefined)
+        fn();
     } else {
       // error code
       fn(new Error('vorbis_analysis_blockout() error: ' + rtn));
@@ -274,7 +275,7 @@ Encoder.prototype._flushpacket = function (output, fn) {
       // got a packet, output it
       // the consumer should call `pageout()` after this packet
       packet.pageout = true;
-      output(packet);
+      self.push(packet);
 
       // attempt to get another `ogg_packet`...
       self._flushpacket(output, fn);


### PR DESCRIPTION
These changes made the encoder work for me. Tested using the example in the README (with a 32-bit float PCM file instead of stdin) and it worked marvelously.

The big issue seemed to be the attempts to use "output" (which, in the scopes involved, I understand to be the "encoding" parameter (a string) provided by the Transform API) as a function for writing the OGG data. The docs [here](http://nodejs.org/api/stream.html#stream_transform_transform_chunk_encoding_callback) showed that transform.push(buffer) is the appropriate way of doing that.
