### PR TITLE
Fix encoder for node stream transform api.

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -97,7 +97,7 @@ Encoder.prototype.addComment = function (tag, contents) {
  * @api private
  */
 
-Encoder.prototype._transform = function (buf, output, fn) {
+Encoder.prototype._transform = function (buf, enc, fn) {
   debug('_transform(%d bytes)', buf.length);
 
   // ensure the vorbis header has been output first
@@ -105,7 +105,7 @@ Encoder.prototype._transform = function (buf, output, fn) {
   if (this._headerWritten) {
     process();
   } else {
-    this._writeHeader(output, process);
+    this._writeHeader(enc, process);
   }
 
   // time to write the PCM buffer to the vorbis encoder
@@ -117,7 +117,7 @@ Encoder.prototype._transform = function (buf, output, fn) {
   // after the PCM buffer has been written, read out the encoded "block"s
   function written (err) {
     if (err) return fn(err);
-    self._blockout(output, fn);
+    self._blockout(enc, fn);
   }
 };
 
@@ -128,7 +128,7 @@ Encoder.prototype._transform = function (buf, output, fn) {
  * @api private
  */
 
-Encoder.prototype._writeHeader = function (output, fn) {
+Encoder.prototype._writeHeader = function (enc, fn) {
   debug('_writeHeader()');
 
   // encoder init (only VBR currently supported)
@@ -166,12 +166,12 @@ Encoder.prototype._writeHeader = function (output, fn) {
   op_comments.replace();
   op_code.replace();
 
-  output(op_header); // automatically gets placed in its own `ogg_page`
-  output(op_comments);
+  this.push(op_header); // automatically gets placed in its own `ogg_page`
+  this.push(op_comments);
 
   // specify that a page flush() call is required after this 3rd packet
   op_code.flush = true;
-  output(op_code);
+  this.push(op_code);
 
   // don't call this function again
   this._headerWritten = true;
@@ -204,7 +204,9 @@ Encoder.prototype._writepcm = function (buf, fn) {
 
     if (0 === rtn) {
       // success
-      fn();
+      if (fn) {
+        fn();
+      }
     } else {
       // error code
       fn(new Error('vorbis_analysis_write() error: ' + rtn));
@@ -220,7 +222,7 @@ Encoder.prototype._writepcm = function (buf, fn) {
  * @api private
  */
 
-Encoder.prototype._blockout = function (output, fn) {
+Encoder.prototype._blockout = function (enc, fn) {
   debug('_blockout');
   var vd = this.vd;
   var vb = this.vb;
@@ -239,10 +241,12 @@ Encoder.prototype._blockout = function (output, fn) {
       r = binding.vorbis_bitrate_addblock(vb);
       //console.error('vorbis_bitrate_addblock() = %d', r);
 
-      self._flushpacket(output, afterFlush);
+      self._flushpacket(enc, afterFlush);
     } else if (0 === rtn) {
       // need more PCM data...
-      fn();
+      if (fn) {
+        fn();
+      }
     } else {
       // error code
       fn(new Error('vorbis_analysis_blockout() error: ' + rtn));
@@ -251,7 +255,7 @@ Encoder.prototype._blockout = function (output, fn) {
   function afterFlush (err) {
     if (err) return fn(err);
     // now attempt to read another "block"
-    self._blockout(output, fn);
+    self._blockout(enc, fn);
   }
 };
 
@@ -262,7 +266,7 @@ Encoder.prototype._blockout = function (output, fn) {
  * @api private
  */
 
-Encoder.prototype._flushpacket = function (output, fn) {
+Encoder.prototype._flushpacket = function (enc, fn) {
   debug('_flushpacket()');
   var self = this;
   var packet = new ogg_packet();
@@ -274,13 +278,15 @@ Encoder.prototype._flushpacket = function (output, fn) {
       // got a packet, output it
       // the consumer should call `pageout()` after this packet
       packet.pageout = true;
-      output(packet);
+      self.push(packet);
 
       // attempt to get another `ogg_packet`...
-      self._flushpacket(output, fn);
+      self._flushpacket(enc, fn);
     } else if (0 === rtn) {
       // need more "block" data
-      fn();
+      if (fn) {
+        fn();
+      }
     } else {
       // error code
       fn(new Error('vorbis_bitrate_flushpacket() error: ' + rtn));
@@ -296,20 +302,20 @@ Encoder.prototype._flushpacket = function (output, fn) {
  * @api private
  */
 
-Encoder.prototype._flush = function (output, fn) {
+Encoder.prototype._flush = function (enc, fn) {
   debug('_onflush()');
 
   // ensure the vorbis header has been output first
   if (this._headerWritten) {
     process.call(this);
   } else {
-    this._writeHeader(output, process);
+    this._writeHeader(enc, process);
   }
 
   function process () {
     var r = binding.vorbis_analysis_eos(this.vd, 0);
     if (0 === r) {
-      this._blockout(output, fn);
+      this._blockout(enc, fn);
     } else {
       // error code
       fn(new Error('vorbis_analysis_eos() error: ' + r));


### PR DESCRIPTION
Encoder continues to use unsupported stream transcoder api that does not work in many versions of node including 0.10, 0.12, 4.2. Fixed and tested in 4.2, but should also work in 0.10 and 0.12 as the transcoder API hasn't changed. Decoder seems to already have these fixes in place. 